### PR TITLE
Fix: 'preexec_functions' -> 'precmd_functions' for updating window title.

### DIFF
--- a/zshrc
+++ b/zshrc
@@ -451,7 +451,7 @@ update_title() {
 }
 ## X環境上でだけウィンドウタイトルを変える。
 if [ -n "$DISPLAY" ]; then
-    preexec_functions=($preexec_functions update_title)
+    precmd_functions=($precmd_functions update_title)
 fi
 
 # node.js


### PR DESCRIPTION
ターミナルのタイトルに表示されるディレクトリ名がワンテンポ遅れる不具合を修正しました。

不具合の再現方法:
cdコマンドでディレクトリを移動しながら、ターミナルのタイトルのディレクトリ名を見てみてください。カレントディレクトリではなく、コマンド実行直前にいた(一歩前の)ディレクトリ名が表示されます。

修正の方針:
表示のタイミングの問題ですので、'preexec_functions'の代わりに、'postexec_functions'みたいなのを使えば良さそう、と思いましたが、Zshには'postexec_functions'というものは存在しませんでした。代替案として、'precmd_functions'を使ってみました。これは、(cdなどの)コマンド実行後、次のプロンプトが出る直前に実行されるようです。
